### PR TITLE
Remove chrome lightouse

### DIFF
--- a/lib/prerender_rails.rb
+++ b/lib/prerender_rails.rb
@@ -34,7 +34,8 @@ module Rack
         'nuzzel',
         'Discordbot',
         'Google Page Speed',
-        'Qwantify'
+        'Qwantify',
+        'Chrome-Lighthouse'
       ]
 
       @extensions_to_ignore = [

--- a/lib/prerender_rails.rb
+++ b/lib/prerender_rails.rb
@@ -105,7 +105,7 @@ module Rack
         prerendered_response = get_prerendered_page_response(env,use_second_service)
 
         if prerendered_response
-          response = build_rack_response_from_prerender(prerendered_response)
+          response = build_rack_response_from_prerender(prerendered_response, env)
           after_render(env, prerendered_response)
           return response.finish
         end
@@ -221,14 +221,14 @@ module Rack
     end
 
 
-    def build_rack_response_from_prerender(prerendered_response)
+    def build_rack_response_from_prerender(prerendered_response, env)
       header = prerendered_response.header
 
       header['Content-Length'] = prerendered_response.body.length
 
       response = Rack::Response.new(prerendered_response.body, prerendered_response.code, header)
 
-      @options[:build_rack_response_from_prerender].call(response, prerendered_response) if @options[:build_rack_response_from_prerender]
+      @options[:build_rack_response_from_prerender].call(response, prerendered_response, env) if @options[:build_rack_response_from_prerender]
 
       response
     end

--- a/lib/prerender_rails.rb
+++ b/lib/prerender_rails.rb
@@ -35,7 +35,9 @@ module Rack
         'Discordbot',
         'Google Page Speed',
         'Qwantify',
-        'Chrome-Lighthouse'
+        'Chrome-Lighthouse',
+        'SemrushBot',
+        'AhrefsSiteAudit'
       ]
 
       @extensions_to_ignore = [

--- a/lib/prerender_rails.rb
+++ b/lib/prerender_rails.rb
@@ -222,7 +222,11 @@ module Rack
 
 
     def build_rack_response_from_prerender(prerendered_response)
-      response = Rack::Response.new(prerendered_response.body, prerendered_response.code, prerendered_response.header)
+      header = prerendered_response.header
+
+      header['Content-Length'] = prerendered_response.body.length
+
+      response = Rack::Response.new(prerendered_response.body, prerendered_response.code, header)
 
       @options[:build_rack_response_from_prerender].call(response, prerendered_response) if @options[:build_rack_response_from_prerender]
 


### PR DESCRIPTION
Hi Gardocki, I am using your repository and would need the following change to avoid treating Chrome-Lightouse as a bot; in this way it is possible to test the Web Vitals without prerendering. Many thanks